### PR TITLE
Added Dockerfiles backend and frontend

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,0 +1,18 @@
+# syntax=docker/dockerfile:1
+
+FROM golang:1.21.4
+
+WORKDIR /app
+
+COPY go.mod go.sum ./
+RUN go mod download
+
+COPY *.go ./
+
+# Build
+RUN CGO_ENABLED=0 GOOS=linux go build -o /amalanche-backend
+
+EXPOSE 8080
+
+# Run
+CMD ["/amalanche-backend"]

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -7,7 +7,7 @@ WORKDIR /app
 COPY go.mod go.sum ./
 RUN go mod download
 
-COPY *.go ./
+COPY . ./
 
 # Build
 RUN CGO_ENABLED=0 GOOS=linux go build -o /amalanche-backend

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,8 +6,38 @@ services:
     container_name: ama-postgres
     image: postgres:15.4
     restart: always
+    networks:
+      - network1
     environment:
       POSTGRES_USER: postgres
       POSTGRES_PASSWORD: postgres
     ports:
       - "5432:5432"
+
+  backend:
+    container_name: ama-backend
+    depends_on:
+      - postgres
+    build:
+      context: backend
+      dockerfile: Dockerfile
+    environment:
+      DB_HOST: postgres  
+    networks:
+      - network1
+    ports:
+      - "8080:8080"
+
+  frontend:
+    container_name: ama-frontend
+    build:
+      context: frontend
+      dockerfile: Dockerfile
+    networks:
+      - network1
+    ports:
+      - "3000:3000"
+
+networks:
+  network1:
+    

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -2,7 +2,7 @@ FROM node:21.2.0
 
 WORKDIR /usr/src/app
 
-COPY package.json package-lock.json ./
+COPY . .
 
 RUN npm install
-CMD [ "npm run" ]
+CMD [ "npm" , "start" ]

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,0 +1,8 @@
+FROM node:21.2.0
+
+WORKDIR /usr/src/app
+
+COPY package.json package-lock.json ./
+
+RUN npm install
+CMD [ "npm run" ]


### PR DESCRIPTION
Added dockerfiles to build and run the backend and the frontend using docker. 

in the parent folder `AMAlanche` run `docker-compose up`

The images created are for development purposes only. 
As future improvement we could add dockerfiles for testing/linting and for production deployments.